### PR TITLE
Fix typos and standardize formatting.

### DIFF
--- a/01_introduction.qmd
+++ b/01_introduction.qmd
@@ -8,6 +8,7 @@ A regression model is a way to express a relationship between some response and 
 - output variable
 
 Likewise, the following may be used interchangeably:
+
 - predictor
 - predictor variable
 - independent variable
@@ -28,18 +29,25 @@ These are the parts of the workshop:
 
 --------------------
 ## The linear model
-Let's say what we mean by a "linear model". This is an equation that describes some output variable as a linear function of some input variable(s).
 
-Note that the linear model is a relationship, while linear regression is a method of estimating that relationship. But since it is by far the most common way of estimating that relationship, the terms are often used interchangeably.
+A **linear model** is an equation that describes some output variable as a linear function of some input variable(s).
 
-The data for a linear model are typically in a spreadsheet format, where each row of data is called an "observation" and each column is called a "feature". The column that is the outcome of the model is called the "response". Each observation should include a value for every feature (there are some ways of handling missing data but that's beyond our scope for this workshop).
+Note that the linear model is a relationship, while **linear regression** is a method of estimating that relationship. But since it is by far the most common way of estimating that relationship, the terms are often used interchangeably.
+
+The data for a linear model are typically in a tabular format (imagine a
+spreadsheet), where each row of data is called an **observation** and each
+column is called a **feature**. The column that is the outcome of the model is
+called the **response**. Each observation should include a value for every
+feature (there are some ways of handling missing data but that's beyond our
+scope for this workshop).
 
 ### Preparation
+
 Your computer will do whatever you tell it to do, even if it's not a good idea. With this great power comes the responsibility to think, and to check your assumptions.
 
 The first one to mention is the assumption that there is a relationship between the features and the response, of the type that the model describes. Your first, best way to test that assumption is to plot the data. Summaries like the means, variances, and correlations can only tell you so much. The following example points out why.
 
-The Datasaurus dozen are a collection of thirteen data sets consisting of two features (x and y) that have the same means, variances, and correlations.
+The Datasaurus Dozen are a collection of thirteen data sets. Each consists of two features (x and y) that have the same means, variances, and correlations.
 
 
 

--- a/02_linear_model.qmd
+++ b/02_linear_model.qmd
@@ -1,7 +1,9 @@
 # Linear Regression
+
 Linear regression means drawing a straight line through a scatterplot of the data. That's easy to picture when there is a single feature, so let's look at an example.
 
 ## Palmer penguins data
+
 This first example will use data from the [`palmerpenguins` package](https://allisonhorst.github.io/palmerpenguins/). It was created by Allison Horst and contains observations of 344 penguins from the Palmer Station Antarctica LTER site. There are eight features: year, species, sex, island, bill width (mm), bill length (mm), flipper length (mm), and body mass (g). We'll begin by installing and then importing the `palmerpenguins` package, and then loading the data.
 
 ```{r load-penguins}
@@ -40,7 +42,7 @@ Suppose we think that all penguins grow in a certain proportional way. Then we m
 #| message: false
 ggplot(penguins) +
   aes(x=flipper_length_mm, y=body_mass_g) +
-  geom_point() + 
+  geom_point() +
   xlab("Flipper length (mm)") +
   ylab("Penguin mass (g)") +
   geom_smooth(method='lm', se=FALSE)
@@ -49,7 +51,10 @@ ggplot(penguins) +
 I've added a regression line to illustrate the assumed linear relationship. Obviously, you'd want your model of the response to fit perfectly but there's no line that would go through all the points.
 
 ## Residuals
-We have a special term for the difference between the fitted line and the dots. We call the differences residuals, and there is one per dot. The difference is calculated as the vertical distance, as shown here:
+
+We have a special term for the difference between the fitted line and the dots.
+We call the differences **residuals**, and there is one per dot. The difference
+is calculated as the vertical distance, as shown here:
 
 ```{r residual-example}
 #| echo: false
@@ -57,7 +62,7 @@ We have a special term for the difference between the fitted line and the dots. 
 #| message: false
 ggplot(penguins) +
   aes(x=flipper_length_mm, y=body_mass_g) +
-  geom_point() + 
+  geom_point() +
   xlab("Flipper length (mm)") +
   ylab("Penguin mass (g)") +
   geom_smooth(method='lm', se=FALSE) +
@@ -87,14 +92,14 @@ library(cowplot)
 
 regression_plot = ggplot(penguins) +
   aes(x=flipper_length_mm, y=body_mass_g) +
-  geom_point() + 
+  geom_point() +
   xlab("Flipper length (mm)") +
   ylab("Penguin mass (g)") +
   geom_smooth(method='lm', se=FALSE)
 
 mean_plot = ggplot(penguins) +
   aes(x=flipper_length_mm, y=body_mass_g) +
-  geom_point() + 
+  geom_point() +
   xlab("Flipper length (mm)") +
   ylab("Penguin mass (g)") +
   geom_hline(
@@ -105,9 +110,13 @@ mean_plot = ggplot(penguins) +
 cowplot::plot_grid(regression_plot, mean_plot, ncol=2)
 ```
 
-A large negative error may be a good thing for "minimizing" error, but we don't want that because the error is large. So the errors are *squared* before adding them together. This is the origin of terms you might have heard, like the sum of squared errors or the mean squared error.
+A large negative error may be a good thing for "minimizing" error, but we don't
+want that because the error is large. So the errors are *squared* before adding
+them together. This is the origin of terms you might have heard, like the **sum
+of squared errors** or the **mean squared error**.
 
 ### The `lm()` function in R
+
 The function to estimate a linear regression model in R is called `lm()`. We'll get quite familiar with the function during this workshop. Now let's use it to estimate the regression line in our penguin body size example.
 
 ```{r lm-first-example}
@@ -131,15 +140,16 @@ In contrast, the coefficient p-values, reported as `Pr(>|t|)` in the `Coefficien
 
 
 ## Assumptions of linear regression
+
 There are a few assumptions about your data that come with linear regression. Before you can accept the results, you must check these:
 
 1. Linearity: The actual relationship between the features and the response is linear. A trend in the fitted vs. residual plot is evidence that the linearity assumption may be wrong. 
 
-2. Check that the residuals have a normal distribution. You can check this via the Q-Q plot, which should have all the dots in an approximately straight line.
+2. Normality: Check that the residuals have a normal distribution. You can check this via the Q-Q plot, which should have all the dots in an approximately straight line.
 
 3. Constant/equal residual variance: The residuals should have the same variability, also called the scale. Confirm this by the location-scale plot. 
 
-4. The residuals must be independent of each other. You can't actually check this from the data, so you have to think carefully about how the value of one residual might depend upon others (for instance if they are measured at locations that touch, maybe there is something that affects both.) Data collection should be planned in order to have independent responses.
+4. Independence: The residuals must be independent of each other. You can't actually check this from the data, so you have to think carefully about how the value of one residual might depend upon others (for instance if they are measured at locations that touch, maybe there is something that affects both.) Data collection should be planned in order to have independent responses.
 
 Let's check the assumptions on the penguin body size model:
 
@@ -166,13 +176,13 @@ We can reasonably assume that penguins with longer flippers and heavier bodies a
 #| message: false
 bill_plot_1 = ggplot(penguins) +
   aes(x=flipper_length_mm, y=bill_length_mm) +
-  geom_point() + 
+  geom_point() +
   xlab("Flipper length (mm)") +
   ylab("Bill length (mm)")
 
 bill_plot_2 = ggplot(penguins) +
   aes(x=body_mass_g, y=bill_length_mm) +
-  geom_point() + 
+  geom_point() +
   xlab("Body mass (g)") +
   ylab("Bill length (mm)")
 
@@ -191,11 +201,19 @@ summary(correlated_model)
 The estimated coefficient has changed from `r round(coef(penguin_mass_model)[[2]], 1)` to `round(coef(correlated_model)[[2]], 1)` and the standard error of the estimated coefficient for `flipper_length_mm` is `r summary(correlated_model)$coefficients[["flipper_length_mm", "Std. Error"]] |> round(1)`, which is 32% greater than the previous standard error of `r summary(penguin_mass_model)$coefficients[["flipper_length_mm", "Std. Error"]] |> round(1)`.
 
 ### Which features to include?
-A common question is how to decide which features to include in a model. A definitive answer is probably impossible, since the "best" model depends on the goal of the analysis, and model selection frequently ends in marginal and somewhat subjective decisions. In the simplest terms, the correct features for your model are the ones that are relevant to your analysis.
 
+A common question is how to decide which features to include in a model.
+There's no definitive answer, since the "best" model depends on the goal of the
+analysis, and model selection frequently ends in marginal and somewhat
+subjective decisions. In the simplest terms, the correct features for your
+model are the ones that are relevant to your analysis.
 
-
-If your goal is to study is to understand the effect that some specific features have on the response, then it's best to decide what those are before trying to estimate the model, and of course you have to keep in mind assumption (1) for linear models: "The actual relationship between the features and the response is linear." This is a theory-driven approach to model selection, because you begin with an idea of the model you want to fit, and then tell the computer to estimate it.
+If your goal is to study the relationship between some specific features and
+the response, then it's best to select those features before fitting a model,
+and of course you have to keep in mind assumption (1) for linear models: "The
+actual relationship between the features and the response is linear." This is a
+theory-driven approach to model selection, because you begin with an idea of
+the model you want to fit, and then tell the computer to estimate it.
 
 There are data-driven ways of doing model selection, most of which can be summarized as: try a model and then change it to get a better fit. These approaches are dangerous because they tend to over-fit the training data, which usually makes the model less useful for future data. In order to mitigate that risk, a portion of the data has to be held out from the model fitting, to test the model with.
 
@@ -218,6 +236,3 @@ plot(seatbelt_model)
 
 
 --->
-
-
-

--- a/03_categorical_continuous.qmd
+++ b/03_categorical_continuous.qmd
@@ -1,7 +1,10 @@
 # Categorical features
+
 Categorical data are a common occurrence in regression modeling. These are any data that consist of categories rather than numbers. For instance, in a forestry experiment, you may thin the trees in some plots and do a prescribed burn in others. "Prescribed burn" and "thinning" aren't numerical values, they are categories of treatment.
 
-There is a grey area where categories are ordered, like low, medium, high. We will talk about two ways to handle those.
+Sometimes categories have a natural order, like low, medium, high, which blurs
+the distinction between categorical and numerical data. We'll also cover ways
+to handle these.
 
 ```{r hidden-load}
 #| echo: false
@@ -28,7 +31,7 @@ named.contr.sum<-function(x, ...) {
         stop("cannot create names with integer value. Pass factor levels")
     }
     x<-contr.sum(x, ...)
-    colnames(x) <- apply(x,2,function(x) 
+    colnames(x) <- apply(x,2,function(x)
         paste(names(x[x>0]), "mean", sep="-")
     )
     x
@@ -37,13 +40,24 @@ named.contr.sum<-function(x, ...) {
 
 
 ## Factors
-In R, categorical variables are called *factors*. Deep down in the machinery of a regression model, factor effects are handled the same way as continuous features But to fully appreciate this, you have to understand that the factors are coded differently than continuous features. To begin, we should note that linear regression for factor variables is also a kind of scatterplot smoother. Let's look at an example:
+
+In R, categorical variables are called **factors**. Deep down in the machinery
+of a regression model, factor effects are handled the same way as continuous
+features. To fully appreciate this, you have to understand that factors are
+coded differently than continuous features. To begin, note that linear
+regression for factor variables is also a kind of scatterplot smoother. Let's
+look at an example:
 
 ### Penguin body mass
-The plot shows the mass of penguins measured at the Palmer Station LTER site in Antarctica, with the data coming from Allison Horst's [`palmerpenguins` package](https://allisonhorst.github.io/palmerpenguins/).
+
+The plot below shows the mass of penguins measured at the Palmer Station LTER
+site in Antarctica, with the data coming from Allison Horst's [`palmerpenguins`
+package][penguins].
+
+[penguins]: https://allisonhorst.github.io/palmerpenguins/
 
 ```{r penguins-spp-example}
-ggplot(penguins) + 
+ggplot(penguins) +
   aes(x=species, y=body_mass_g) +
   geom_point() +
   ggtitle("Body mass of penguins by species") +
@@ -84,13 +98,24 @@ print(penguin_means)
 Notice that the fitted value of the `(Intercept)` is identical to the average mass of an Adelie penguin, and that there are two rows of species effects, instead of the one row that we saw for the continuous effects so far. The values of the `Estimate` column in those rows are the estimated effects for Chinstrap and Gentoo penguins - and they are equal to the difference between the average mass of those penguins and Adelie penguins.
 
 ### Design matrix
+
 The reason that the results look like this can be made more clear if you look at the way R converts the categories to numbers. The `model.matrix()` is the function that R uses internally to prepare data for an `lm()`, but we can call it ourselves. Remember that linear regression works by multiplying each term by a coefficient, adding adding the results together. Here, we have three terms for the three species. Adelie has been automatically selected as the reference level because it appears first in the data.
 
 ```{r penguin-model-matrix}
 tail(model.matrix(penguin_lm))
 ```
 
-Here, we have three terms: `(Intercept)`, `speciesChinstrap`, and `speciesGentoo`. So to calculate the mass that is estimated for row 12, we will add `1 * (Intercept) + 1 * speciesGentoo`. Since the effect `(Intercept)` is the average mass of the Adelie penguins, the effect `speciesGentoo` must be the difference between the mean mass of Gentoo penguins and the mean mass of Adelie penguins.  Why no term for `speciesAdelie`? It's because the fit would then depend on how mass was apportioned between the penguin species and the intercept. You could increase the intercept by 10 grams and reduce all three species estimates by 10 grams and end up with the same model fit, despite different effects. The computer has no way of deciding between those options, because it just optimizing the model fit.
+Here, we have three terms: `(Intercept)`, `speciesChinstrap`, and
+`speciesGentoo`. So to calculate the mass that is estimated for row 12, we will
+add `1 * (Intercept) + 1 * speciesGentoo`. Since the effect `(Intercept)` is
+the average mass of the Adelie penguins, the effect `speciesGentoo` must be the
+difference between the mean mass of Gentoo penguins and the mean mass of Adelie
+penguins.  Why no term for `speciesAdelie`? It's because the fit would then
+depend on how mass was apportioned between the penguin species and the
+intercept. You could increase the intercept by 10 grams and reduce all three
+species estimates by 10 grams and end up with the same model fit, despite
+different effects. The computer has no way of deciding between those options,
+because it is just minimizing the model error.
 
 You don't have to set one factor level to be the reference for estimation, but that goes beyond the scope of this introductory workshop. You may need to change which level is the reference, and that is within our scope. R has a function `relevel()`, which takes the argument `ref=`, which specifies the reference level of a factor. Here is how it would work to set Gentoo as the reference level:
 
@@ -112,7 +137,11 @@ predict(releveled_penguin_model, pred_df)
 
 ## Combining continuous and categorical
 
-Of course, continuous and categorical features don't have to be kept separate. We'll return to our original example and consider whether the relationship between a penguin's mass and its flipper length is different between the three species. You combine categorical and continuous features by adding them together in the formula. 
+Of course, continuous and categorical features don't have to be kept separate.
+We'll return to our original example and consider whether the relationship
+between a penguin's mass and its flipper length is different between the three
+species. You combine categorical and continuous features by adding them
+together in the model formula. 
 
 ```{r no_interation_model}
 # create a model with both species and flipper length as features
@@ -128,7 +157,7 @@ Here is a visualization of the model fit:
 penguins$nointeract = predict(combo_model, newdata=penguins)
 ggplot(penguins) +
   aes(x=flipper_length_mm, y=body_mass_g, color=species) +
-  geom_point() + 
+  geom_point() +
   xlab("Flipper length (mm)") +
   ylab("Penguin mass (g)") +
   geom_smooth(data=penguins,
@@ -151,7 +180,7 @@ plot(combo_model)
 summary(combo_model)
 ```
 
-The summary tells up how big are the differences between the species-specific intercepts. The diagnostic plots still exhibit a "U" shape in the Fitted Vs. Residual plot, so we haven't yet found an ideal regression model for this data.
+The summary shows how big the differences are between the species-specific intercepts. The diagnostic plots still exhibit a "U" shape in the Fitted Vs. Residual plot, so we haven't yet found an ideal regression model for this data.
 
 ## Interactions
 
@@ -163,7 +192,7 @@ We can improve this model further by adding an interaction between the species a
 #| message: false
 ggplot(penguins) +
   aes(x=flipper_length_mm, y=body_mass_g, color=species) +
-  geom_point() + 
+  geom_point() +
   xlab("Flipper length (mm)") +
   ylab("Penguin mass (g)") +
   geom_smooth(method='lm', se=FALSE)

--- a/04_generalized_linear_model.qmd
+++ b/04_generalized_linear_model.qmd
@@ -48,8 +48,13 @@ To view and interpret a GLM, use the `summary()` function, just as you did for a
 
 --->
 
-# Generalized linear regression
-We won't put much emphasis on generalized linear models (GLMs) in this workshop, but they are important and so you might want to know about them. GLMs are used when the response variable has some distribution other than normal - logistic regression (binary response) is by far the most commonly used GLM and Poisson regression (count response) is fairly common, too. In any case, the differences between an ordinary linear model and a generalized linear model are fairly minor. 
+# Generalized linear models
+
+**Generalized linear models** (GLMs) are used when the response variable has
+some distribution other than normal - logistic regression (binary response) is
+by far the most commonly used GLM and Poisson regression (count response) is
+fairly common, too. In spite of this, there are many similarities between
+ordinary linear models and a generalized linear models.
 
 - Response distribution is different. As a result:
   - Response variance is no longer assumed equal (when variance depends on mean).
@@ -57,7 +62,8 @@ We won't put much emphasis on generalized linear models (GLMs) in this workshop,
   - Thus, diagnostics have to change.
 
 ### Logistic Regression - UC Berkeley Admissions
-The `UCBAdmissions` dataset is built into R and provides a tabulation of how many men and women applied and were admitted to six departments at UC Berkeley in 1973. Suppose we want to estimate whether male or female applicants were more likely than the other to be admitted. Since each admission decision is binary, we will use a generalized linear model with binomial response to estimate the effect of gender on admission probability. The data are built-in as an array so we need to convert them to a data frame before getting started.
+
+The `UCBAdmissions` data set is built into R and provides a tabulation of how many men and women applied and were admitted to six departments at UC Berkeley in 1973. Suppose we want to estimate whether male or female applicants were more likely to be admitted. Since each admission decision is binary, we will use a generalized linear model with binomial response to estimate the effect of gender on admission probability. The data are built-in as an array so we need to convert them to a data frame before getting started.
 
 ```{r convert-ucb-data}
 library(tidyr)
@@ -67,7 +73,13 @@ ucb = as.data.frame(UCBAdmissions) |>
 ucb
 ```
 
-Now fit the binomial regression model for admission probability. By default, R uses logistic regression for a binomial response. Because the observations are aggregated by gender and department, we have to pair the `Admitted` and `Rejected` columns as the response. If each row represented a single observation and the `Admitted` column were coded as 0/1 or `TRUE`/`FALSE`, we could use it alone as the response.
+Now fit the binomial regression model for admission probability. By default,
+the `glm` function uses logistic regression for a binomial response. The
+observations are aggregated by gender and department, so we have to pair the
+`Admitted` and `Rejected` columns as the response. If each row represented a
+single observation and the `Admitted` column were coded as 0/1 or
+`TRUE`/`FALSE`, we could use it alone as the response.
+
 ```{r ucb-model}
 # estimate a logistic regression model.
 ucb_model = glm(cbind(Admitted, Rejected) ~ Dept + Gender, data=ucb, family='binomial')
@@ -82,13 +94,14 @@ summary(ucb_model)
 
 Diagnostics are especially difficult to interpret for logistic regression models with a small amount of data. These look only OK. According to the model summary, there are significant differences in admission rates by departments and not by gender.
 
-For a logistic regression model, the estimated coefficients are reported as log odds ratios. A log odds ratio greater than zero corresponds to probability greater than 50%, and vice versa. Both `Dept` and `Gender` are categorical, so you can figure the estimated log odds ratio for a particular combination by adding the relevant rows from the summary table. The default level of this combination is `Male` and `DeptA`.
+For a logistic regression model, the estimated coefficients are reported as
+**log odds ratios**. A log odds ratio greater than zero corresponds to
+probability greater than 50%, and vice versa. Both `Dept` and `Gender` are
+categorical, so you can figure out the estimated log odds ratio for a
+particular combination by adding the relevant rows from the summary table. The
+default level of this combination is `Male` and `DeptA`.
 
 <!---This data has often been used to illustrate Simpson's Paradox, because overall men were admitted at a greater rate than women, but this may be because women applied to more selective departments. --->
-
-
-
-
 
 <!---
 ## Poisson Regression - Effectiveness of Bug Sprays
@@ -103,6 +116,3 @@ plot(model_spray)
 
 
 ...)
-
-
-

--- a/05_fixed_random_effects.qmd
+++ b/05_fixed_random_effects.qmd
@@ -1,6 +1,5 @@
-
-
 # Fixed and Random Effects
+
 We have looked at several examples of regression models. For the examples, I have intentionally chosen data with a pretty simple structure: all of the observations are independent, with differences in the outcomes attributed to either the treatment effects or to random noise.
 
 ```{r hidden-load}
@@ -22,26 +21,52 @@ penguins_small = subset(penguins, !is.na(body_mass_g)) |>
 
 
 ## Fixed effects
-The effects we've seen so far are often called "fixed effects". That's because the treatment is expected to have the same effect if the experiment were repeated. That fixed value is in contrast to "random effects", which are taken from a random distribution and are expected to be different in a hypothetical repetition of the experiment.
 
+The effects we've seen so far are often called **fixed effects**. That's
+because the treatment is expected to have the same effect if the experiment
+were repeated. That fixed value is in contrast to **random effects**, which are
+taken from a random distribution and are expected to be different in a
+hypothetical repetition of the experiment.
+
+<!-- FIXME: Same header appears twice. -->
+
+## Random effects
+
+Real-world science often sees data grouped according to some known structure of
+the study. For instance, in an agricultural experiment, the yield of plants
+from the same field is generally more alike than plants from different fields,
+even if all fields in question received the same treatment. Why? Maybe the soil
+was generally better quality in one field, or one got more rain than the other,
+or the treatments weren't applied with perfect consistency across fields.
+
+In order to account for factors like these, agricultural researchers divide
+fields into plots and apply a different treatment to each plot. Then two
+measurements from the same plot are generally more alike than two from
+different plots, even in the same field. By the same reasoning, measurements
+from two plots in the same field are generally more alike than measurements
+from two plots in different fields. This is an example of hierarchical data:
+there are several individual measurements from plants in each plot. We say that
+the measurements are nested within the plots, and the plots are nested within
+the fields. 
 
 
 ## Random effects
-Real-world science often sees data grouped according to some known structure of the study. For instance, in an agricultural experiment, the yield of plants from the same field is generally more alike than plants from different fields, even fields that received the same treatment. Why? Maybe the soil was generally better quality in one field, or one got more rain than the other, or the treatments weren't applied perfectly consistently between fields.
 
-In order to account for factors like these, agricultural experiments often divide a field into plots, and apply different treatments in each plot. In that case, the yields from the same plot are more alike than from other plots, even on the same field. But they are generally more alike within the same field than plots from different fields. This is an example of hierarchical data: there are several individual measurements of yield from plants in each plot. We say that the measurements are nested within the plots, and meanwhile the plots are nested within fields. 
-
-
-
-
-## Random effects
 Random effects are a way to account for variation in data that arises due to grouping or clustering of observations. They are used in regression models when there is a hierarchy or structure in the data, and the observations within each group are expected to be correlated.
 
 For example, in a study involving students from different schools, random effects can be used to capture the inherent differences between schools, which may affect the dependent variable (e.g., test scores). Random effects are modeled as deviations from the overall population-level effects.
 
 
-## Using random effects in regression 
-There are several R packages that implement random effects in regression. `lme4` is the most-used and `brms` is the Bayesian equivalent (which also offers some great features that aren't available in `lme4`.) Both of them write the model in just about the same way as the `lm()` and `glm()` functions that you've already seen. The only difference is that the random effects need to be specified using a special notation: they are written as two parts wrapped in parentheses. The first part indicates the effect that changes with the grouping factor, and the second part indicates what variable is the grouping factor.
+## Using random effects in regression
+
+There are several R packages that implement random effects in regression.
+`lme4` is the most-used and `brms` is the Bayesian equivalent (which also
+offers some great features that aren't available in `lme4`.) Both of them use a
+formula syntax similar to the `lm()` and `glm()` functions that you've already
+seen. The only difference is that the random effects need to be specified using
+a special notation: they are written as two parts wrapped in parentheses. The
+first part indicates the effect that changes with the grouping factor, and the
+second part indicates what variable is the grouping factor.
 
 ```{r random-effects-model}
 re_model = lmer(Reaction ~ Days + (1|Subject), data=sleepstudy)
@@ -65,7 +90,20 @@ ggplot(sleepstudy) +
 
 
 ### Random intercepts and slopes
-The most common kind of random effect is a random intercept. That means the effect of a grouping level is a consistent adjustment (increase or decrease) to the response. But random effects can be more complicated, such random slopes - where the effect of a continuous variable changes according to the grouping variable. Here's an example using the sleep study data: the difference is that now the random effect of subject is not only that each subject was has somewhat quicker or slower reflexes that change by the same amount each day. Instead, each subject has somewhat quicker or slower reflexes that change by a personally unique amount each day (meanwhile, we have still estimated the fixed effect of days - which is the amount that an average person's reaction time slowed down with each day of sleep deprivation.
+
+The most common kind of random effect is a **random intercept**. That means the
+effect of a grouping level is a consistent adjustment (increase or decrease) to
+the response. But random effects can be more complicated, such **random
+slopes** - where the effect of a continuous variable changes according to the
+grouping variable.
+
+Here's an example using the sleep study data: the difference is that now the
+random effect of subject is not only that each subject was has somewhat quicker
+or slower reflexes that change by the same amount each day. Instead, each
+subject has somewhat quicker or slower reflexes that change by a personally
+unique amount each day (meanwhile, we have still estimated the fixed effect of
+days - which is the amount that an average person's reaction time slowed down
+with each day of sleep deprivation.
 
 ```{r random-slope-model}
 random_slope_model = lmer(Reaction ~ Days + (1 + Days|Subject), data=sleepstudy)
@@ -97,14 +135,34 @@ summary(random_slope_model)
 
 
 ## When to use fixed vs random effects
-There isn't a single, definitive check that will tell you when to use random or fixed effects. I have come to think of random effects as a form of "partial pooling" - a way to do something between te extremes of either treating each observation as independent, or fully pooling all observations of each group by only using group means as data. With random effects, the amount of pooling is adaptive: where the differences between groups are large compared to the difference between observations within a group, then the random effect for group will have a big influence. But where the differences between individual observations is large compared to 
 
+<!-- FIXME: This paragraph ends mid-sentence. -->
+
+There isn't a single, definitive check that will tell you when to use random or
+fixed effects. I have come to think of random effects as a form of "partial
+pooling" - a way to do something between the extremes of either treating each
+observation as independent, or fully pooling all observations of each group by
+only using group means as data. With random effects, the amount of pooling is
+adaptive: where the differences between groups are large compared to the
+difference between observations within a group, then the random effect for
+group will have a big influence. But where the differences between individual
+observations is large compared to 
 
 
 ## Examples:
 
 ### Orange trees
-For this example, we will look at the growth of orange trees. The data is in the built-in dataset `Orange`, which you can import via $data(Orange)$. There are three columns: `Tree`, which is an ID of which orange tree is being measured; `age`, which is the number of days since Deember 31, 1969; and `circumference`, which is the circumference of the tree's trunk (in mm). There are five trees with seven observations each, so 35 rows of data. First, plot the data:
+
+For this example, we will investigate orange tree growth using the built-in
+data set `Orange`. You can load the data set via `data(Orange)`. There are
+three columns:
+
+1. `Tree`, which is an ID of which orange tree is being measured;
+2. `age`, which is the number of days since Deember 31, 1969;
+3. `circumference`, which is the circumference of the tree's trunk (in mm).
+
+There are five trees with seven observations each, so there are 35 rows of
+data. First, plot the data:
 
 ```{r orange-raw-plot}
 # plot the orange tree data
@@ -119,9 +177,3 @@ This looks like (fairly) linear growth with the same intercept (all the trees ap
 model_orange = lmer(circumference ~ (age - 1 | Tree), data=Orange)
 summary(model_orange)
 ```
-
-
-
-
-
-

--- a/index.qmd
+++ b/index.qmd
@@ -33,14 +33,13 @@ output:
 # Overview {-}
 
 # Description
-Regression modeling — using input variables to predict or model the value of a response — is widely used in pretty much every field of research. Yet many graduate programs don't include formal training in statistical modeling, and the DataLab's office hours indicate widespread anxiety about using regression models in practice. This workshop is intended to help address that anxiety by teaching the fundamentals of using regression modeling in practice. The emphasis is on practice and intuition, with only a small amount of math. This workshop is open to all UC Davis graduate students and postdoctoral scholars. Attendance at both sessions is required. Instruction is in-person and seats are limited. A Zoom link (e.g., broadcast) will be available for those unable to attend who would  like to watch live.
+Regression modeling — using input variables to predict or model the value of a response — is widely used in pretty much every field of research. Yet many graduate programs don't include formal training in statistical modeling, and the DataLab's office hours indicate widespread anxiety about using regression models in practice. This workshop is intended to help address that anxiety by teaching the fundamentals of using regression modeling. The emphasis is on practice and intuition, with only a small amount of math. This workshop is open to all UC Davis graduate students and postdoctoral scholars. Attendance at both sessions is required. Instruction is in-person and seats are limited. A Zoom link (e.g., broadcast) will be available for those unable to attend who would like to watch live.
 
 # Learning objectives
 After this workshop, learners will be able to:
-- Understand the differences between linear and generalized linear regression models
-- Understand the difference between fixed effects and random effects in regression models
-- Understand how continuous and categorical variables are handled differently in regression modeling software
+- Explain the differences between linear and generalized linear regression models
+- Explain the differences between fixed effects and random effects
+- Describe how continuous and categorical variables are handled differently by regression modeling software
 - Implement the above-mentioned model types
 - Read and interpret regression summary tables
-- Do diagnostic checks on your regression models
- 
+- Do diagnostic checks on regression models


### PR DESCRIPTION
Fixes to various typos and attempts to standardize the formatting (e.g., use **boldface** when new vocabulary is defined).

Also see two `FIXME`s in `05_fixed_random_effects.qmd`.